### PR TITLE
Display a number over removed shapes, fade out.

### DIFF
--- a/assets/skins/mySkin/mySkin.json
+++ b/assets/skins/mySkin/mySkin.json
@@ -3,7 +3,7 @@ com.badlogic.gdx.graphics.g2d.BitmapFont: {
 	Play-Bold20white: {
 		file: Play-Bold20white.fnt
 		scaledSize: 1
-		markupEnabled: false
+		markupEnabled: true
 		flip: false
 	}
 	Play-Bold40white: {

--- a/core/src/main/java/no/sandramoen/libgdx31/screens/gameplay/Grid.java
+++ b/core/src/main/java/no/sandramoen/libgdx31/screens/gameplay/Grid.java
@@ -1,5 +1,9 @@
 package no.sandramoen.libgdx31.screens.gameplay;
 
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.scenes.scene2d.Touchable;
+import com.badlogic.gdx.utils.Align;
+import com.github.tommyettinger.textra.Styles;
 import no.sandramoen.libgdx31.actors.Shape;
 import no.sandramoen.libgdx31.screens.shell.LevelSelectScreen;
 import no.sandramoen.libgdx31.utils.AssetLoader;
@@ -184,10 +188,17 @@ public class Grid {
                 })));
 
                 // feature TODO: label that shows the score you get.
-                /*TypingLabel label = new TypingLabel("0", AssetLoader.getLabelStyle("Play-Bold20white"));
-                label.scaleBy(0.05f);
-                label.setPosition(shape.getX(), shape.getY());
-                mainStage.addActor(label);*/
+                Styles.LabelStyle style = AssetLoader.getLabelStyle("Play-Bold20white");
+                // This is sometimes needed when a Viewport uses 1 unit to mean "1 Mario" or "1 Sonic".
+                style.font.scaleHeightTo(1f);
+                style.fontColor = Color.LIGHT_GRAY;
+                TypingLabel label = new TypingLabel("0", style);
+                label.setPosition(shape.getX() + shape.getWidth() * 0.5f,
+                                  shape.getY() + shape.getHeight() * 0.5f,
+                                  Align.center);
+                label.setTouchable(Touchable.disabled);
+                mainStage.addActor(label);
+                label.addAction(Actions.sequence(Actions.parallel(Actions.moveBy(MathUtils.randomTriangular(0.8f), 1.5f + MathUtils.randomTriangular(0.4f), 2f), Actions.fadeOut(2f)), Actions.removeActor()));
 
                 // Immediately set the grid position to null as the shape is marked for removal
                 Vector2 shapePosition = shape.getGridPosition();

--- a/core/src/main/java/no/sandramoen/libgdx31/utils/AssetLoader.java
+++ b/core/src/main/java/no/sandramoen/libgdx31/utils/AssetLoader.java
@@ -7,18 +7,22 @@ import com.badlogic.gdx.assets.AssetManager;
 import com.badlogic.gdx.assets.loaders.resolvers.InternalFileHandleResolver;
 import com.badlogic.gdx.audio.Music;
 import com.badlogic.gdx.audio.Sound;
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.TextureAtlas;
 import com.badlogic.gdx.maps.tiled.TiledMap;
 import com.badlogic.gdx.maps.tiled.TmxMapLoader;
 import com.badlogic.gdx.scenes.scene2d.ui.Skin;
 import com.badlogic.gdx.utils.Array;
+import com.github.tommyettinger.textra.FWSkin;
+import com.github.tommyettinger.textra.FWSkinLoader;
+import com.github.tommyettinger.textra.Font;
 import com.github.tommyettinger.textra.Styles;
 
 public class AssetLoader implements AssetErrorListener {
 
     public static TextureAtlas textureAtlas;
-    public static Skin mySkin;
+    public static FWSkin mySkin;
 
     public static String defaultShader;
     public static String shockwaveShader;
@@ -47,6 +51,7 @@ public class AssetLoader implements AssetErrorListener {
     static {
         long time = System.currentTimeMillis();
         BaseGame.assetManager = new AssetManager();
+        BaseGame.assetManager. setLoader(Skin. class, new FWSkinLoader(BaseGame.assetManager. getFileHandleResolver()));
         BaseGame.assetManager.setErrorListener(new AssetLoader());
 
         loadAssets();
@@ -62,7 +67,10 @@ public class AssetLoader implements AssetErrorListener {
     }
 
     public static Styles.LabelStyle getLabelStyle(String fontName) {
-        return new Styles.LabelStyle(AssetLoader.mySkin.get(fontName, BitmapFont.class), null);
+        return new Styles.LabelStyle(
+            new Font(
+                AssetLoader.mySkin.get(fontName, Font.class)
+            ), Color.WHITE);
     }
 
     private static void loadAssets() {
@@ -142,7 +150,7 @@ public class AssetLoader implements AssetErrorListener {
         backgroundShader = BaseGame.assetManager.get("shaders/voronoi.fs", Text.class).getString();
 
         // skins
-        mySkin = new Skin(Gdx.files.internal("skins/mySkin/mySkin.json"));
+        mySkin = new FWSkin(Gdx.files.internal("skins/mySkin/mySkin.json"));
 
         // fonts
         loadFonts();
@@ -154,12 +162,12 @@ public class AssetLoader implements AssetErrorListener {
     }
 
     private static void loadFonts() {
-        float scale = Gdx.graphics.getWidth() * .001f; // magic number ensures scale ~= 1, based on screen width
+        float scale = Gdx.graphics.getWidth() * .05f; // magic number ensures scale ~= 1, based on screen width
         scale *= 1.01f; // make x percent bigger, bigger = more fuzzy
 
-        mySkin.getFont("Play-Bold20white").getData().setScale(scale);
-        mySkin.getFont("Play-Bold40white").getData().setScale(scale);
-        mySkin.getFont("Play-Bold59white").getData().setScale(scale);
+        mySkin.get("Play-Bold20white", Font.class).scale(scale);
+        mySkin.get("Play-Bold40white", Font.class).scale(scale);
+        mySkin.get("Play-Bold59white", Font.class).scale(scale);
     }
 
     private static void loadTiledMap() {


### PR DESCRIPTION
This seems to work... There are some other small changes relating to loading styles; I may be able to improve those. The numbers are currently always '0', but they do at least move in slightly varied directions, always up but not the same.